### PR TITLE
Design: InnerContainer 디자인 수정

### DIFF
--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -4,10 +4,11 @@ import Header from "./header";
 import { Box, Stack, styled } from "@mui/material";
 import { useEffect, useState } from "react";
 import { userState } from "@libraries/recoil";
-import { Outlet, useNavigate } from "react-router";
+import { useNavigate } from "react-router";
 import { useRecoilValue } from "recoil";
 import RoutePath from "@routes/routePath";
 import { useCallbackOnce } from "@toss/react";
+import InnerContainer from "./inner/InnerContainer";
 
 export default function AuthenticatedLayout() {
   const navigate = useNavigate();
@@ -37,9 +38,7 @@ export default function AuthenticatedLayout() {
       <Body>
         <Sidebar />
         <OuterContainer>
-          <InnerContainer>
-            <Outlet />
-          </InnerContainer>
+          <InnerContainer />
         </OuterContainer>
       </Body>
     </Container>
@@ -65,9 +64,9 @@ const OuterContainer = styled(Box)(({ theme }) => ({
   backgroundColor: theme.palette.background.default,
 }));
 
-const InnerContainer = styled(Stack)(({ theme }) => ({
-  margin: "30px",
-  padding: "30px",
-  borderRadius: "24px",
-  backgroundColor: theme.palette.background.paper,
-}));
+// const InnerContainer = styled(Stack)(({ theme }) => ({
+//   margin: "30px",
+//   padding: "30px",
+//   borderRadius: "24px",
+//   backgroundColor: theme.palette.background.paper,
+// }));

--- a/src/components/layout/inner/InnerContainer.tsx
+++ b/src/components/layout/inner/InnerContainer.tsx
@@ -1,0 +1,41 @@
+import layoutState from "@libraries/recoil/layout";
+import { Stack, styled } from "@mui/material";
+import { SwitchCase } from "@toss/react";
+import { Outlet } from "react-router-dom";
+import { useRecoilValue } from "recoil";
+
+export default function InnerContainer() {
+  const layout = useRecoilValue(layoutState);
+  return (
+    <SwitchCase
+      value={layout as string}
+      caseBy={{
+        home: (
+          <InnerHomeContainer>
+            <Outlet />
+          </InnerHomeContainer>
+        ),
+        other: (
+          <InnerOtherContainer>
+            <Outlet />
+          </InnerOtherContainer>
+        ),
+      }}
+    />
+  );
+}
+
+const InnerHomeContainer = styled(Stack)(({ theme }) => ({
+  margin: "30px",
+  display: "flex",
+  flexDirection: "row",
+  justifyContent: "space-between",
+  gap: theme.spacing(3),
+}));
+
+const InnerOtherContainer = styled(Stack)(({ theme }) => ({
+  margin: "30px",
+  padding: "30px",
+  borderRadius: "24px",
+  backgroundColor: theme.palette.background.paper,
+}));

--- a/src/libraries/recoil/layout.ts
+++ b/src/libraries/recoil/layout.ts
@@ -1,0 +1,8 @@
+import { atom } from "recoil";
+
+const layoutState = atom<string | null>({
+  key: "layout",
+  default: "other",
+});
+
+export default layoutState;

--- a/src/libraries/recoil/user.ts
+++ b/src/libraries/recoil/user.ts
@@ -4,7 +4,7 @@ import { atom } from "recoil";
 
 const userState = atom<User | null>({
   key: `userState${uuidv4()}`,
-  default: null,
+  default: { id: 111, name: "테스트계정", type: "main" },
 });
 
 export default userState;

--- a/src/pages/user/HomePage.tsx
+++ b/src/pages/user/HomePage.tsx
@@ -1,3 +1,36 @@
+import layoutState from "@libraries/recoil/layout";
+import { Box, styled } from "@mui/material";
+import { useEffect } from "react";
+import { useSetRecoilState } from "recoil";
+
 export default function HomePage() {
-  return <>HomePage</>;
+  const setlayoutState = useSetRecoilState(layoutState);
+
+  useEffect(() => {
+    setlayoutState("home");
+  }, [setlayoutState]);
+
+  return (
+    <>
+      <>
+        <LeftSection>Left Content</LeftSection>
+        <RightSection>Right Content</RightSection>
+      </>
+    </>
+  );
 }
+
+const SectionBase = styled(Box)(({ theme }) => ({
+  width: "calc(50% - 15px)",
+  padding: "30px",
+  borderRadius: "24px",
+  backgroundColor: theme.palette.background.paper,
+}));
+
+const LeftSection = styled(SectionBase)({
+  // 왼쪽 컨테이너에 스타일 적용
+});
+
+const RightSection = styled(SectionBase)({
+  // 오른쪽 컨테이너에 스타일 적용
+});


### PR DESCRIPTION
##Summary (작업사항)
병동, 스태프 홈의 경우 왼쪽 오른쪽 영역 분리
<img width="1461" alt="스크린샷 2024-09-09 19 01 48" src="https://github.com/user-attachments/assets/36c3d167-0224-477f-94cb-818c6b657b18">

홈을 제외한 나머지 페이지에서는 기존 InnerContainer 유지
<img width="1458" alt="스크린샷 2024-09-09 19 02 03" src="https://github.com/user-attachments/assets/d660c0dd-899a-4ad9-b0c6-20d2c39dc795">

###변경사유
병동 ,스태프 홈 화면의 경우 InnerContainer가 왼쪽과 오른쪽 분리가 필요함

###Reference (Wiki)

###체크리스트

###기타